### PR TITLE
No longer blocks shell with systemctl status

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ if [ "`systemctl is-active bt_speaker`" != "active" ]; then
 else
   systemctl restart bt_speaker
 fi
-systemctl status bt_speaker
+systemctl status bt_speaker --full --no-pager
 echo "done."
 
 # Finished


### PR DESCRIPTION
Added --full --no-pager options to systemctl status at the end of installation to allow the
script to continue without systemctl status interrupting it and needing
manual intervention.